### PR TITLE
chore(CO-3560): migrate Jenkinsfile to jenkins-lib-common and add semantic-release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ build/
 .project
 .classpath
 .idea
-build.properties

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,18 @@
+library(
+    identifier: 'jenkins-lib-common@v2.7.0',
+    retriever: modernSCM([
+        $class: 'GitSCMSource',
+        credentialsId: 'jenkins-integration-with-github-account',
+        remote: 'git@github.com:zextras/jenkins-lib-common.git',
+    ])
+)
+
+properties(defaultPipelineProperties())
+
 pipeline {
     agent {
         node {
-            label 'carbonio-agent-v1'
+            label 'zextras-v1'
         }
     }
     environment {
@@ -18,50 +29,50 @@ pipeline {
         stage('Checkout') {
             steps {
                 checkout scm
+                script {
+                    gitMetadata()
+                    semanticRelease.guard()
+                }
+                container('jdk-21') {
+                    sh 'apt-get update -qq && apt-get install -y ant -qq'
+                }
+            }
+        }
+        stage('Security Scan') {
+            steps {
+                gitleaksStage()
+            }
+        }
+        stage('Bump version') {
+            when {
+                expression { env.GIT_IS_DEFAULT_BRANCH == 'true' }
+            }
+            steps {
+                script {
+                    semanticRelease(github: true)
+                }
             }
         }
         stage('Build') {
             steps {
-                withCredentials([file(credentialsId: 'artifactory-jenkins-gradle-properties', variable: 'CREDENTIALS')]) {
-                    sh '''
-                        cat <<EOF > build.properties
-                        debug=0
-                        is-production=1
-                        carbonio.buildinfo.version=22.5.0_ZEXTRAS_202205
-                        EOF
-                       '''
-                    sh "cat ${CREDENTIALS} | sed -E 's#\\\\#\\\\\\\\#g' >> build.properties"
-                    sh '''
-                        ANT_RESPECT_JAVA_HOME=true JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/ ant \
-                             -propertyfile build.properties \
-                             jar
-                        '''
+                withCredentials([usernamePassword(credentialsId: 'artifactory-jenkins-gradle-properties-splitted', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_PASSWORD')]) {
+                    container('jdk-21') {
+                        sh 'ant -propertyfile build.properties -Dartifactory_user="${ARTIFACTORY_USER}" -Dartifactory_password="${ARTIFACTORY_PASSWORD}" jar'
+                    }
                 }
             }
         }
-
         stage('Publish to maven') {
             when {
                 buildingTag()
             }
             steps {
-                withCredentials([file(credentialsId: 'artifactory-jenkins-gradle-properties', variable: 'CREDENTIALS')]) {
-                    sh '''
-                        cat <<EOF > build.properties
-                        debug=0
-                        is-production=1
-                        carbonio.buildinfo.version=22.5.0_ZEXTRAS_202205
-                        EOF
-                       '''
-                    sh "cat ${CREDENTIALS} | sed -E 's#\\\\#\\\\\\\\#g' >> build.properties"
-                    sh '''
-                        ANT_RESPECT_JAVA_HOME=true JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/ ant \
-                             -propertyfile build.properties \
-                             publish-maven-all
-                        '''
+                withCredentials([usernamePassword(credentialsId: 'artifactory-jenkins-gradle-properties-splitted', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_PASSWORD')]) {
+                    container('jdk-21') {
+                        sh 'ant -propertyfile build.properties -Dartifactory_user="${ARTIFACTORY_USER}" -Dartifactory_password="${ARTIFACTORY_PASSWORD}" publish-maven-all'
+                    }
                 }
             }
         }
     }
 }
-

--- a/build-common.xml
+++ b/build-common.xml
@@ -3,7 +3,8 @@
   <dirname property="zimbra.root.dir" file="${ant.file.build-common}/../" />
   <dirname property="zm-mailbox.basedir" file="${ant.file.build-common}" />
   <!-- Java -->
-  <property name="javac.target" value="11" />
+  <property name="javac.target" value="21" />
+  <property name="javac.source" value="21" />
   <!-- base path for ivy cache, local repository, ant libraries, etc -->
 
   <property name="dev.home" value="${user.home}" />
@@ -264,7 +265,7 @@
 
   <target name="compile" depends="build-init,resolve,3rd-party-defines" description="Compiles from src/java into build/classes.">
     <mkdir dir="${build.classes.dir}" />
-    <javac destdir="${build.classes.dir}" debug="true" classpathref="class.path" target="${javac.target}" encoding="utf-8">
+    <javac destdir="${build.classes.dir}" debug="true" classpathref="class.path" source="${javac.source}" target="${javac.target}" encoding="utf-8">
       <src refid="all.java.path" />
     </javac>
   </target>
@@ -274,7 +275,7 @@
       <available file="${test.src.dir}" type="dir" />
       <antcontrib:then>
         <mkdir dir="${test.classes.dir}" />
-        <javac destdir="${test.classes.dir}" srcdir="${test.src.dir}" classpathref="test.class.path" debug="true" target="${javac.target}" encoding="utf-8" />
+        <javac destdir="${test.classes.dir}" srcdir="${test.src.dir}" classpathref="test.class.path" debug="true" source="${javac.source}" target="${javac.target}" encoding="utf-8" />
         <copy todir="${test.classes.dir}">
           <fileset dir="${test.src.dir}" excludes="**/*.java" />
         </copy>
@@ -509,7 +510,7 @@
                 </echo>
       </then>
     </antcontrib:if>
-    <javac destdir="${build.classes.dir}" debug="true" target="${javac.target}" srcdir="${build.dir}/buildinfo" />
+    <javac destdir="${build.classes.dir}" debug="true" source="${javac.source}" target="${javac.target}" srcdir="${build.dir}/buildinfo" />
   </target>
 
   <target name="zextras-jar" depends="generate-jar-version,set-dev-version,3rd-party-defines" description="Builds a standard jar file that prints its version info when executed.  Optionally sets the Zimbra-Extension-Class attribute in the manifest if the zimbra.extension.class property is set.">

--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,3 @@
+debug=0
+is-production=1
+carbonio.buildinfo.version=4.0.3

--- a/release.config.mjs
+++ b/release.config.mjs
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: 2026 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+/**
+ * @type {import('semantic-release').GlobalConfig}
+ */
+export default {
+  branches: ['main'],
+  tagFormat: "${version}",
+  plugins: [
+    [
+      '@semantic-release/commit-analyzer',
+      {
+        preset: 'conventionalcommits',
+        releaseRules: [
+          // enable release also for refactor and build commits
+          { type: 'refactor', release: 'patch' },
+          { type: 'build', release: 'patch' },
+          { type: 'ci', release: 'patch' },
+          { type: 'chore', 'scope': 'release', 'release': false},
+          { type: 'perf', release: 'patch' }
+        ]
+      }
+    ],
+    [
+      '@semantic-release/release-notes-generator',
+      {
+        preset: 'conventionalcommits',
+        presetConfig: {
+          // see https://github.com/conventional-changelog/conventional-changelog-config-spec/blob/master/versions/2.2.0/README.md#types
+          types: [
+            {
+              type: 'feat',
+              section: 'Features',
+              hidden: false
+            },
+            {
+              type: 'fix',
+              section: 'Bug Fixes',
+              hidden: false
+            },
+            {
+              type: 'refactor',
+              section: 'Other changes',
+              hidden: false
+            },
+            {
+              type: 'perf',
+              section: 'Other changes',
+              hidden: false
+            },
+            {
+              type: 'build',
+              section: 'Other changes',
+              hidden: false
+            },
+            {
+              type: 'ci',
+              section: 'Other changes',
+              hidden: false
+            }
+          ]
+        }
+      }
+    ],
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "sed -i 's/carbonio.buildinfo.version=.*/carbonio.buildinfo.version=${nextRelease.version}/' build.properties"
+      }
+    ],
+    [
+      '@semantic-release/git',
+      {
+        assets: ['build.properties'],
+        message: 'chore(release): ${nextRelease.version} [skip ci]'
+      }
+    ],
+    '@semantic-release/github'
+  ]
+};


### PR DESCRIPTION
## Summary

Closes #6

Part of [CO-3560](https://zextras.atlassian.net/browse/CO-3560) — Migrate java libraries to semantic release.

- Switch to `jenkins-lib-common@v2.7.0` shared library
- Use `zextras-v1` node label and `jdk-21` container
- Add `gitMetadata()`, `semanticRelease.guard()`, `gitleaksStage()`
- Replace dead file credential (`artifactory-jenkins-gradle-properties`) with `usernamePassword` binding (`artifactory-jenkins-gradle-properties-splitted`)
- Add `semanticRelease(github: true)` bump stage, guarded on `GIT_IS_DEFAULT_BRANCH`
- Add `release.config.mjs` for semantic-release configuration
- Install `ant` in `jdk-21` container (no dedicated ant image available)
- Update `javac` source/target to 21 in `build-common.xml`

[CO-3560]: https://zextras.atlassian.net/browse/CO-3560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ